### PR TITLE
multiple bounding boxes, cameras, and rolling averages 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,23 @@ models that summarize information from underlying vision models for waiting
 
 https://app.viam.com/module/viam/queue-estimator
 
-Using an underlying camera and vision service, you can use information from the vision service to measure crowding around an area of interest.
+Using an underlying set of cameras and vision service, you can use information from the vision service to measure crowding around areas of interest.
 
-You specify the area of interset by filling out the cropping box attribute in the config. If the cropping box is empty, the sensor will use the entire scene.
+You specify the areas of interset by filling out the `valid_regions` attribute in the config. If the cropping box list for a camera is empty, the sensor will use the entire scene from that camera.
 
-Rather than just counting how many people are there in the area of interest (which could jump wildly up and down as people pass) to determine whether there a wait time, the algo instead counts to see if enough people are in that area of interest over a period of time (as determined by the sampling_period_s) and then updates the state of the queue as appropriate. The levels of crowdedness are determined by by the "count_thresholds", as well as how many samples (n_samples) have been taken within the counting period.
+Rather than just counting the sum of people in the areas of interest (which could jump wildly up and down as people pass) to determine whether there a wait time, the algo instead counts to see if enough people are in those areas of interest over a period of time (as determined by the sampling_period_s) and then updates the state of the queue as appropriate. The levels of crowdedness are determined by by the "count_thresholds", as well as how many samples (n_samples) have been taken within the counting period.
 
+The level of crowdedness is updated continously usually a rolling average based on the past n_samples from the regions of the interest.
 ## Example Config
 
 ### wait-sensor
-- sampling_period_s: this is how long to gather data before updating the state of the queue estimator.
+- sampling_period_s: this is how long to "look back" for in order to make a decision based on average crowdedness over this time period.
 - n_samples: how often to poll the underlying vision service within the sampling_period_s. 
-- count_threshold: the corresponding string associated with the count. the value is the upper-bound of the trigger count. Anything below this number will be give the associated string label.
+- valid_regions: the underlying cameras and regions of interest within the respective camera scenes the vision service detector should use.
+- count_threshold: the corresponding string associated with the count for one sample. the value is the upper-bound of the trigger count. Anything below this number will be give the associated string label.
 - detector_name: the underlying vision service detector to use
-- camera_name: the underlying camera the vision service detector should use
 - chosen_labels: what are the labels  and confidence scores of the underlying vision service that should count towards the count.
 - extra_fields: any extra fields that should be copied to the sensor output
-- cropping_box: `[x_min, y_min, x_max, y_max]` to crop the image to, and only count objects within that box. the box is using relative scale to the image dimension, e.g. `[0.3, .0.25, 0.8, 0.68]`
 ```
 "name": "queue-sensor",
 "namespace": "rdk",
@@ -35,9 +35,12 @@ Rather than just counting how many people are there in the area of interest (whi
   },
   "sampling_period_s": 10,
   "n_samples": 5, # will measure the crowd every 2 seconds
-  "cropping_box": [0.3, 0.33, 0.6. 0.65],
+  "valid_regions": {
+     "camera_3": [[0.3, 0.33, 0.6. 0.65]],
+     "camera_12": [[0.2, 0.1, 0.3, 0.3], [0.75, 0.75, 1.0, 1.0]],
+     "camera_44": [], # this means use the whole camera scene
+  },
   "detector_name": "vision-1",
-  "camera_name": "camera-1",
   "chosen_labels": {
     "person": 0.3
   },

--- a/waitsensor/waitsensor.go
+++ b/waitsensor/waitsensor.go
@@ -15,6 +15,7 @@ import (
 
 	"go.viam.com/rdk/components/camera"
 	"go.viam.com/rdk/components/sensor"
+	"go.viam.com/rdk/gostream"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
 	"go.viam.com/rdk/services/vision"
@@ -47,23 +48,24 @@ func init() {
 // Config contains names for necessary resources
 type Config struct {
 	DetectorName    string                 `json:"detector_name"`
-	CameraName      string                 `json:"camera_name"`
 	ChosenLabels    map[string]float64     `json:"chosen_labels"`
 	CountThresholds map[string]int         `json:"count_thresholds"`
 	CountPeriod     float64                `json:"sampling_period_s"`
 	NSamples        int                    `json:"n_samples"`
 	ExtraFields     map[string]interface{} `json:"extra_fields"`
-	CropArea        []float64              `json:"cropping_box"`
+	ValidRegions    map[string][][]float64 `json:"valid_regions"`
 }
 
 // Validate validates the config and returns implicit dependencies,
 // this Validate checks if the camera and detector exist for the module's vision model.
 func (cfg *Config) Validate(path string) ([]string, error) {
+	camAndDetNames := []string{}
 	if cfg.DetectorName == "" {
 		return nil, errors.New("attribute detector_name cannot be left blank")
 	}
-	if cfg.CameraName == "" {
-		return nil, errors.New("attribute camera_name cannot be left blank")
+	camAndDetNames = append(camAndDetNames, cfg.DetectorName)
+	if len(cfg.ValidRegions) == 0 {
+		return nil, errors.New("attribute valid_regions cannot be left blank")
 	}
 	if len(cfg.CountThresholds) == 0 {
 		return nil, errors.New("attribute count_thresholds is required")
@@ -81,25 +83,16 @@ func (cfg *Config) Validate(path string) ([]string, error) {
 		}
 		testMap[v] = label
 	}
-	if len(cfg.CropArea) != 0 {
-		coords := cfg.CropArea
-		if len(coords) != 4 {
-			return nil, errors.Errorf("cropping_box must contain 4 numbers [x_min, y_min, x_max, y_max], attribute specifies %v numbers.", len(coords))
-		}
-		for _, e := range coords {
-			if e < 0.0 || e > 1.0 {
-				return nil, errors.New("cropping_box numbers are relative to the image dimension, and must be numbers between 0 and 1.")
+	for camName, listBB := range cfg.ValidRegions {
+		camAndDetNames = append(camAndDetNames, camName)
+		for _, coords := range listBB {
+			_, err := NewBoundingBox(coords)
+			if err != nil {
+				return nil, errors.Wrapf(err, "error in valid_region for %v", camName)
 			}
 		}
-		xMin, yMin, xMax, yMax := coords[0], coords[1], coords[2], coords[3]
-		if xMin >= xMax {
-			return nil, fmt.Errorf("x_min (%f) must be less than x_max (%f)", xMin, xMax)
-		}
-		if yMin >= yMax {
-			return nil, fmt.Errorf("y_min (%f) must be less than y_max (%f)", yMin, yMax)
-		}
 	}
-	return []string{cfg.DetectorName, cfg.CameraName}, nil
+	return camAndDetNames, nil
 }
 
 // Bin stores the thresholds that turns counts into labels
@@ -128,6 +121,57 @@ func NewThresholds(t map[string]int) []Bin {
 	return out
 }
 
+type BoundingBox struct {
+	relBox []float64
+}
+
+func NewBoundingBox(coords []float64) (BoundingBox, error) {
+	if len(coords) != 0 {
+		if len(coords) != 4 {
+			return BoundingBox{}, errors.Errorf("bounding box must contain 4 numbers [x_min, y_min, x_max, y_max], got %v.", coords)
+		}
+		for _, e := range coords {
+			if e < 0.0 || e > 1.0 {
+				return BoundingBox{}, errors.New("bounding box numbers are relative to the image dimension, and must be numbers between 0 and 1.")
+			}
+		}
+		xMin, yMin, xMax, yMax := coords[0], coords[1], coords[2], coords[3]
+		if xMin >= xMax {
+			return BoundingBox{}, fmt.Errorf("x_min (%f) must be less than x_max (%f)", xMin, xMax)
+		}
+		if yMin >= yMax {
+			return BoundingBox{}, fmt.Errorf("y_min (%f) must be less than y_max (%f)", yMin, yMax)
+		}
+	}
+	return BoundingBox{relBox: coords}, nil
+}
+
+// crop coordinates were already validated upon configuration
+// empty bounding box implies no crop
+func (bb BoundingBox) Crop(img image.Image) image.Image {
+	coords := bb.relBox
+	if len(coords) != 4 {
+		return img
+	}
+	xMin, yMin, xMax, yMax := coords[0], coords[1], coords[2], coords[3]
+	// Get image bounds
+	bounds := img.Bounds()
+	width := bounds.Max.X - bounds.Min.X
+	height := bounds.Max.Y - bounds.Min.Y
+
+	// Convert relative coordinates to absolute pixels
+	x1 := bounds.Min.X + int(xMin*float64(width))
+	y1 := bounds.Min.Y + int(yMin*float64(height))
+	x2 := bounds.Min.X + int(xMax*float64(width))
+	y2 := bounds.Min.Y + int(yMax*float64(height))
+
+	// Create cropping rectangle
+	rect := image.Rect(x1, y1, x2, y2)
+	croppedImg := image.NewRGBA(image.Rect(0, 0, rect.Dx(), rect.Dy()))
+	draw.Draw(croppedImg, croppedImg.Bounds(), img, rect.Min, draw.Src)
+	return croppedImg
+}
+
 type counter struct {
 	resource.Named
 	cancelFunc              context.CancelFunc
@@ -135,16 +179,15 @@ type counter struct {
 	activeBackgroundWorkers sync.WaitGroup
 	logger                  logging.Logger
 	detName                 string
-	camName                 string
 	detector                vision.Service
-	cam                     camera.Camera
+	cams                    map[string]camera.Camera
+	validRegions            map[string][]BoundingBox
 	labels                  map[string]float64
 	thresholds              []Bin
 	frequency               float64
 	numInView               atomic.Int64
 	class                   atomic.Value
 	extraFields             map[string]interface{}
-	cropArea                []float64
 	transitionCount         int
 }
 
@@ -182,7 +225,17 @@ func (cs *counter) Reconfigure(ctx context.Context, deps resource.Dependencies, 
 	if countConf.ExtraFields != nil {
 		cs.extraFields = countConf.ExtraFields
 	}
-	cs.cropArea = countConf.CropArea
+	cs.validRegions = make(map[string][]BoundingBox)
+	for camName, bbList := range countConf.ValidRegions {
+		cs.validRegions[camName] = []BoundingBox{}
+		for _, coords := range bbList {
+			bb, err := NewBoundingBox(coords)
+			if err != nil {
+				return errors.Wrapf(err, "error in valid region for %v", camName)
+			}
+			cs.validRegions[camName] = append(cs.validRegions[camName], bb)
+		}
+	}
 	// transition time in seconds
 	transitionTime := DefaultTransitionTime
 	if countConf.CountPeriod > 0 {
@@ -191,10 +244,14 @@ func (cs *counter) Reconfigure(ctx context.Context, deps resource.Dependencies, 
 	cs.transitionCount = countConf.NSamples
 	cs.frequency = transitionTime / float64(cs.transitionCount)
 	cs.logger.Infof("number of samples/time between state change for queue estimator, n_samples: %v, time (s): %v", cs.transitionCount, transitionTime)
-	cs.camName = countConf.CameraName
-	cs.cam, err = camera.FromDependencies(deps, countConf.CameraName)
-	if err != nil {
-		return errors.Wrapf(err, "unable to get camera %v for count classifier", countConf.CameraName)
+	cs.cams = make(map[string]camera.Camera)
+	for camName, _ := range countConf.ValidRegions {
+		cn := camName
+		cam, err := camera.FromDependencies(deps, cn)
+		if err != nil {
+			return errors.Wrapf(err, "unable to get camera %v for count classifier", cn)
+		}
+		cs.cams[cn] = cam
 	}
 	cs.detName = countConf.DetectorName
 	cs.detector, err = vision.FromDependencies(deps, countConf.DetectorName)
@@ -251,26 +308,51 @@ func (cs *counter) counts2class(count int) string {
 	return OverflowLabel
 }
 
-type CountMap map[string]int
-
-func NewCountMap(thresholds []Bin) CountMap {
-	countMap := CountMap{}
-	for _, thresh := range thresholds {
-		countMap[thresh.Label] = 0
-	}
-	return countMap
+type RingBuffer struct {
+	size     int
+	data     []string
+	current  int
+	full     bool
+	labelMap map[string]int
 }
 
-func (cm CountMap) Reset() {
-	for label, _ := range cm {
-		cm[label] = 0
+func NewRingBuffer(thresholds []Bin, size int) *RingBuffer {
+	data := make([]string, size)
+	labelMap := make(map[string]int)
+	for _, b := range thresholds {
+		labelMap[b.Label] = 0
+	}
+	return &RingBuffer{
+		size:     size,
+		data:     data,
+		labelMap: labelMap,
 	}
 }
 
-func (cm CountMap) MaxLabel() string {
+func (rb *RingBuffer) Add(newLabel string) {
+	oldLabel := rb.data[rb.current]
+	rb.data[rb.current] = newLabel
+	rb.current = (rb.current + 1) % rb.size
+	if rb.current == 0 { // the first time it reaches this again, it will be full
+		rb.full = true
+	}
+	rb.labelMap[newLabel] += 1
+	if rb.full && oldLabel != "" {
+		rb.labelMap[oldLabel] -= 1
+	}
+}
+
+func (rb *RingBuffer) Len() int {
+	if rb.full {
+		return rb.size
+	}
+	return rb.current
+}
+
+func (rb *RingBuffer) MaxLabel() string {
 	maxLab := OverflowLabel
 	maxCount := 0
-	for label, count := range cm {
+	for label, count := range rb.labelMap {
 		if count > maxCount {
 			maxLab = label
 		}
@@ -280,43 +362,46 @@ func (cm CountMap) MaxLabel() string {
 
 func (cs *counter) run(ctx context.Context) error {
 	freq := cs.frequency
-	upperThreshold := cs.transitionCount
-	count := 0
-	countMap := NewCountMap(cs.thresholds)
-	stream, err := cs.cam.Stream(ctx, nil)
-	if err != nil {
-		return err
+	buffer := NewRingBuffer(cs.thresholds, cs.transitionCount)
+	// set up a stream for each camera
+	streams := map[string]gostream.VideoStream{}
+	for camName, cam := range cs.cams {
+		stream, err := cam.Stream(ctx, nil)
+		if err != nil {
+			return err
+		}
+		streams[camName] = stream
+		defer stream.Close(ctx)
 	}
-	defer stream.Close(ctx)
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		default:
 			start := time.Now()
-			img, release, err := stream.Next(ctx)
-			if err != nil {
-				return errors.Errorf("camera error in background thread: %q", err)
+			// process for each stream in the list of cameras
+			totalCounts := 0
+			for camName, bbs := range cs.validRegions {
+				img, release, err := streams[camName].Next(ctx)
+				if err != nil {
+					return errors.Errorf("camera %v error in background thread: %q", camName, err)
+				}
+				for _, bb := range bbs {
+					img = bb.Crop(img)
+					dets, err := cs.detector.Detections(ctx, img, nil)
+					if err != nil {
+						return errors.Errorf("vision service error in background thread: %q", err)
+					}
+					release()
+					c := cs.countDets(dets)
+					totalCounts += c
+				}
 			}
-			if len(cs.cropArea) != 0 {
-				img = crop(img, cs.cropArea)
-			}
-			dets, err := cs.detector.Detections(ctx, img, nil)
-			if err != nil {
-				return errors.Errorf("vision service error in background thread: %q", err)
-			}
-			release()
-			c := cs.countDets(dets)
-			class := cs.counts2class(c)
-			count++
-			countMap[class] += 1 // increment that class for later calculation
-			cs.numInView.Store(int64(c))
-			if count >= upperThreshold {
-				maxClass := countMap.MaxLabel()
-				cs.class.Store(maxClass)
-				count = 0
-				countMap.Reset()
-			}
+			class := cs.counts2class(totalCounts)
+			buffer.Add(class)
+			maxClass := buffer.MaxLabel()
+			cs.numInView.Store(int64(totalCounts))
+			cs.class.Store(maxClass)
 			took := time.Since(start)
 			waitFor := time.Duration((1/freq)*float64(time.Second)) - took // only poll according to set freq
 			if waitFor > time.Microsecond {
@@ -328,27 +413,6 @@ func (cs *counter) run(ctx context.Context) error {
 			}
 		}
 	}
-}
-
-// crop coordinates were already validated upon configuration
-func crop(img image.Image, coords []float64) image.Image {
-	xMin, yMin, xMax, yMax := coords[0], coords[1], coords[2], coords[3]
-	// Get image bounds
-	bounds := img.Bounds()
-	width := bounds.Max.X - bounds.Min.X
-	height := bounds.Max.Y - bounds.Min.Y
-
-	// Convert relative coordinates to absolute pixels
-	x1 := bounds.Min.X + int(xMin*float64(width))
-	y1 := bounds.Min.Y + int(yMin*float64(height))
-	x2 := bounds.Min.X + int(xMax*float64(width))
-	y2 := bounds.Min.Y + int(yMax*float64(height))
-
-	// Create cropping rectangle
-	rect := image.Rect(x1, y1, x2, y2)
-	croppedImg := image.NewRGBA(image.Rect(0, 0, rect.Dx(), rect.Dy()))
-	draw.Draw(croppedImg, croppedImg.Bounds(), img, rect.Min, draw.Src)
-	return croppedImg
 }
 
 // Readings contains both the label and the count of the underlying detector


### PR DESCRIPTION
changes the config to get rid of bounding_box and camera_name in order to have multiple for one:

```
valid_regions: {
   "214-cam-3": [[0.1, 0.2, 0.5, 0.7], [0.7, 0.73, 0.89, 0.90]],
   "214-cam-1": [[0.5, 0.5, 0.6, 0.6]],
   "213-cam-1": [] # empty implies use the whole image
}
```