### PR TITLE
use ModularMain from the RDK instead of copying boilerplate

### DIFF
--- a/cmd/module/main.go
+++ b/cmd/module/main.go
@@ -2,36 +2,13 @@
 package main
 
 import (
-	"context"
-
 	"github.com/viam-modules/queue-estimator/waitsensor"
 	"go.viam.com/rdk/components/sensor"
 
-	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/module"
-	"go.viam.com/utils"
+	"go.viam.com/rdk/resource"
 )
 
 func main() {
-	utils.ContextualMain(mainWithArgs, module.NewLoggerFromArgs("queue-estimator"))
-}
-
-func mainWithArgs(ctx context.Context, args []string, logger logging.Logger) (err error) {
-	myMod, err := module.NewModuleFromArgs(ctx)
-	if err != nil {
-		return err
-	}
-
-	err = myMod.AddModelFromRegistry(ctx, sensor.API, waitsensor.Model)
-	if err != nil {
-		return err
-	}
-
-	err = myMod.Start(ctx)
-	defer myMod.Close(ctx)
-	if err != nil {
-		return err
-	}
-	<-ctx.Done()
-	return nil
+	module.ModularMain(resource.APIModel{API: sensor.API, Model: waitsensor.Model})
 }


### PR DESCRIPTION
The module still compiles, though I haven't tested it more than that.

I'm unable to request reviewers on this PR (maybe I need extra permissions in this repo?), but @bhaney will be interested...