### PR TITLE
[RSDK-9506] explicitly use xMin, yMin, etc. in bounding boxes

### DIFF
--- a/waitsensor/waitsensor.go
+++ b/waitsensor/waitsensor.go
@@ -44,15 +44,22 @@ func init() {
 	})
 }
 
+type BoundingBoxConfig struct {
+	XMin float64 `json:"x_min"`
+	XMax float64 `json:"x_max"`
+	YMin float64 `json:"y_min"`
+	YMax float64 `json:"y_max"`
+}
+
 // Config contains names for necessary resources
 type Config struct {
-	DetectorName    string                 `json:"detector_name"`
-	ChosenLabels    map[string]float64     `json:"chosen_labels"`
-	CountThresholds map[string]int         `json:"count_thresholds"`
-	CountPeriod     float64                `json:"sampling_period_s"`
-	NSamples        int                    `json:"n_samples"`
-	ExtraFields     map[string]interface{} `json:"extra_fields"`
-	ValidRegions    map[string][][]float64 `json:"valid_regions"`
+	DetectorName    string                         `json:"detector_name"`
+	ChosenLabels    map[string]float64             `json:"chosen_labels"`
+	CountThresholds map[string]int                 `json:"count_thresholds"`
+	CountPeriod     float64                        `json:"sampling_period_s"`
+	NSamples        int                            `json:"n_samples"`
+	ExtraFields     map[string]interface{}         `json:"extra_fields"`
+	ValidRegions    map[string][]BoundingBoxConfig `json:"valid_regions"`
 }
 
 // Validate validates the config and returns implicit dependencies,
@@ -124,7 +131,7 @@ type BoundingBox struct {
 	relBox []float64
 }
 
-func NewBoundingBox(coords []float64) (BoundingBox, error) {
+func NewBoundingBox(coords BoundingBoxConfig) (BoundingBox, error) {
 	if len(coords) != 0 {
 		if len(coords) != 4 {
 			return BoundingBox{}, errors.Errorf("bounding box must contain 4 numbers [x_min, y_min, x_max, y_max], got %v.", coords)
@@ -134,7 +141,7 @@ func NewBoundingBox(coords []float64) (BoundingBox, error) {
 				return BoundingBox{}, errors.New("bounding box numbers are relative to the image dimension, and must be numbers between 0 and 1.")
 			}
 		}
-		xMin, yMin, xMax, yMax := coords[0], coords[1], coords[2], coords[3]
+		xMin, yMin, xMax, yMax := coords.XMin, coords.YMin, coords.XMax, coords.YMax
 		if xMin >= xMax {
 			return BoundingBox{}, fmt.Errorf("x_min (%f) must be less than x_max (%f)", xMin, xMax)
 		}
@@ -142,7 +149,7 @@ func NewBoundingBox(coords []float64) (BoundingBox, error) {
 			return BoundingBox{}, fmt.Errorf("y_min (%f) must be less than y_max (%f)", yMin, yMax)
 		}
 	}
-	return BoundingBox{relBox: coords}, nil
+	return BoundingBox{relBox: []float64{xMin, yMin, xMax, yMax}}, nil
 }
 
 // crop coordinates were already validated upon configuration

--- a/waitsensor/waitsensor.go
+++ b/waitsensor/waitsensor.go
@@ -128,7 +128,7 @@ func NewThresholds(t map[string]int) []Bin {
 }
 
 type BoundingBox struct {
-	relBox []float64
+	xMin, yMin, xMax, yMax float64
 }
 
 func NewBoundingBox(coords BoundingBoxConfig) (BoundingBox, error) {
@@ -146,27 +146,30 @@ func NewBoundingBox(coords BoundingBoxConfig) (BoundingBox, error) {
 		return BoundingBox{}, fmt.Errorf(
 			"y_min (%f) must be less than y_max (%f)", coords.YMin, coords.YMax)
 	}
-	return BoundingBox{relBox: coordList}, nil
+	bb := BoundingBox{xMin: coords.XMin,
+					  yMin: coords.YMin,
+	                  xMax: coords.XMax,
+					  yMax: coords.YMax,
+				  }
+	return bb, nil
 }
 
 // crop coordinates were already validated upon configuration
 // empty bounding box implies no crop
 func (bb BoundingBox) Crop(img image.Image) image.Image {
-	coords := bb.relBox
-	if len(coords) != 4 {
+	if bb.xMax == 0 || bb.yMax == 0 {
 		return img
 	}
-	xMin, yMin, xMax, yMax := coords[0], coords[1], coords[2], coords[3]
 	// Get image bounds
 	bounds := img.Bounds()
 	width := bounds.Max.X - bounds.Min.X
 	height := bounds.Max.Y - bounds.Min.Y
 
 	// Convert relative coordinates to absolute pixels
-	x1 := bounds.Min.X + int(xMin*float64(width))
-	y1 := bounds.Min.Y + int(yMin*float64(height))
-	x2 := bounds.Min.X + int(xMax*float64(width))
-	y2 := bounds.Min.Y + int(yMax*float64(height))
+	x1 := bounds.Min.X + int(bb.xMin*float64(width))
+	y1 := bounds.Min.Y + int(bb.yMin*float64(height))
+	x2 := bounds.Min.X + int(bb.xMax*float64(width))
+	y2 := bounds.Min.Y + int(bb.yMax*float64(height))
 
 	// Create cropping rectangle
 	rect := image.Rect(x1, y1, x2, y2)

--- a/waitsensor/waitsensor.go
+++ b/waitsensor/waitsensor.go
@@ -133,23 +133,22 @@ type BoundingBox struct {
 
 func NewBoundingBox(coords BoundingBoxConfig) (BoundingBox, error) {
 	if len(coords) != 0 {
-		if len(coords) != 4 {
-			return BoundingBox{}, errors.Errorf("bounding box must contain 4 numbers [x_min, y_min, x_max, y_max], got %v.", coords)
-		}
-		for _, e := range coords {
+		coordList := []float64{coords.XMin, coords.YMin, coords.XMax, coords.YMax}
+		for _, e := range coordList {
 			if e < 0.0 || e > 1.0 {
 				return BoundingBox{}, errors.New("bounding box numbers are relative to the image dimension, and must be numbers between 0 and 1.")
 			}
 		}
-		xMin, yMin, xMax, yMax := coords.XMin, coords.YMin, coords.XMax, coords.YMax
-		if xMin >= xMax {
-			return BoundingBox{}, fmt.Errorf("x_min (%f) must be less than x_max (%f)", xMin, xMax)
+		if coords.XMin >= coords.XMax {
+			return BoundingBox{}, fmt.Errorf(
+				"x_min (%f) must be less than x_max (%f)", coords.XMin, coords.XMax)
 		}
-		if yMin >= yMax {
-			return BoundingBox{}, fmt.Errorf("y_min (%f) must be less than y_max (%f)", yMin, yMax)
+		if coords.YMin >= coords.YMax {
+			return BoundingBox{}, fmt.Errorf(
+				"y_min (%f) must be less than y_max (%f)", coords.YMin, coords.YMax)
 		}
 	}
-	return BoundingBox{relBox: []float64{xMin, yMin, xMax, yMax}}, nil
+	return BoundingBox{relBox: coordList}, nil
 }
 
 // crop coordinates were already validated upon configuration

--- a/waitsensor/waitsensor.go
+++ b/waitsensor/waitsensor.go
@@ -132,21 +132,19 @@ type BoundingBox struct {
 }
 
 func NewBoundingBox(coords BoundingBoxConfig) (BoundingBox, error) {
-	if len(coords) != 0 {
-		coordList := []float64{coords.XMin, coords.YMin, coords.XMax, coords.YMax}
-		for _, e := range coordList {
-			if e < 0.0 || e > 1.0 {
-				return BoundingBox{}, errors.New("bounding box numbers are relative to the image dimension, and must be numbers between 0 and 1.")
-			}
+	coordList := []float64{coords.XMin, coords.YMin, coords.XMax, coords.YMax}
+	for _, e := range coordList {
+		if e < 0.0 || e > 1.0 {
+			return BoundingBox{}, errors.New("bounding box numbers are relative to the image dimension, and must be numbers between 0 and 1.")
 		}
-		if coords.XMin >= coords.XMax {
-			return BoundingBox{}, fmt.Errorf(
-				"x_min (%f) must be less than x_max (%f)", coords.XMin, coords.XMax)
-		}
-		if coords.YMin >= coords.YMax {
-			return BoundingBox{}, fmt.Errorf(
-				"y_min (%f) must be less than y_max (%f)", coords.YMin, coords.YMax)
-		}
+	}
+	if coords.XMin >= coords.XMax {
+		return BoundingBox{}, fmt.Errorf(
+			"x_min (%f) must be less than x_max (%f)", coords.XMin, coords.XMax)
+	}
+	if coords.YMin >= coords.YMax {
+		return BoundingBox{}, fmt.Errorf(
+			"y_min (%f) must be less than y_max (%f)", coords.YMin, coords.YMax)
 	}
 	return BoundingBox{relBox: coordList}, nil
 }

--- a/waitsensor/waitsensor.go
+++ b/waitsensor/waitsensor.go
@@ -132,8 +132,7 @@ type BoundingBox struct {
 }
 
 func NewBoundingBox(coords BoundingBoxConfig) (BoundingBox, error) {
-	coordList := []float64{coords.XMin, coords.YMin, coords.XMax, coords.YMax}
-	for _, e := range coordList {
+	for _, e := range []float64{coords.XMin, coords.YMin, coords.XMax, coords.YMax} {
 		if e < 0.0 || e > 1.0 {
 			return BoundingBox{}, errors.New("bounding box numbers are relative to the image dimension, and must be numbers between 0 and 1.")
 		}

--- a/waitsensor/waitsensor.go
+++ b/waitsensor/waitsensor.go
@@ -137,11 +137,13 @@ func NewBoundingBox(coords BoundingBoxConfig) (BoundingBox, error) {
 			return BoundingBox{}, errors.New("bounding box numbers are relative to the image dimension, and must be numbers between 0 and 1.")
 		}
 	}
-	if coords.XMin >= coords.XMax {
+	// If our "bounding box" is the whole image, XMax and/or YMax will be 0, in which case it can
+	// be equal to XMin/YMin. Otherwise, make sure the max is larger than the min.
+	if coords.XMax > 0 && coords.XMin >= coords.XMax {
 		return BoundingBox{}, fmt.Errorf(
 			"x_min (%f) must be less than x_max (%f)", coords.XMin, coords.XMax)
 	}
-	if coords.YMin >= coords.YMax {
+	if coords.YMax > 0 && coords.YMin >= coords.YMax {
 		return BoundingBox{}, fmt.Errorf(
 			"y_min (%f) must be less than y_max (%f)", coords.YMin, coords.YMax)
 	}

--- a/waitsensor/waitsensor.go
+++ b/waitsensor/waitsensor.go
@@ -147,10 +147,10 @@ func NewBoundingBox(coords BoundingBoxConfig) (BoundingBox, error) {
 			"y_min (%f) must be less than y_max (%f)", coords.YMin, coords.YMax)
 	}
 	bb := BoundingBox{xMin: coords.XMin,
-					  yMin: coords.YMin,
+	                  yMin: coords.YMin,
 	                  xMax: coords.XMax,
-					  yMax: coords.YMax,
-				  }
+	                  yMax: coords.YMax,
+	                  }
 	return bb, nil
 }
 

--- a/waitsensor/waitsensor_test.go
+++ b/waitsensor/waitsensor_test.go
@@ -1,22 +1,31 @@
 package waitsensor
 
 import (
+	"fmt"
 	"testing"
 
 	"go.viam.com/test"
 )
 
-var validConfig = Config{DetectorName: "test",
+func makeValidConfig() Config {
+	return Config{DetectorName: "test",
 	                     CountPeriod: 5.0,
 	                     NSamples: 10,
+						 CountThresholds: map[string]int{
+							 "one": 1,
+							 "two": 2,
+							 "three": 3,
+						 },
 	                     ValidRegions: map[string][]BoundingBoxConfig{
-	                         "one": {XMin: 0.25,
-	                                 XMin: 0.25,
-	                                 YMax: 0.10,
-	                                 YMax: 0.90,
-	                                 },
+	                         "box": {{XMin: 0.25,
+	                                  XMax: 0.75,
+	                                  YMin: 0.10,
+	                                  YMax: 0.90,
+	                                  }},
 	                     },
 		        	 }
+				 }
+
 
 func TestValidateEmpty(t *testing.T) {
 	cfg := Config{}
@@ -26,15 +35,37 @@ func TestValidateEmpty(t *testing.T) {
 }
 
 func TestValidateCorrect(t *testing.T) {
+	validConfig := makeValidConfig()
 	_, err := validConfig.Validate("")
 	test.That(t, err, test.ShouldBeNil)
 }
 
 func TestValidateInvalidBoundingBox(t *testing.T) {
-	negativeBounds := validConfig
-	negativeBounds.ValidRegions["one"].XMin = -0.2
-	_, err := cfg.Validate("")
-	test.That(t, err, test.ShouldNotBeNil)
-	test.That(t, err.Error(), test.ShouldContainSubstring, "detector_name")
-}
+	var err error
 
+	negativeXBounds := makeValidConfig()
+	negativeXBounds.ValidRegions["box"][0].XMin = -0.2
+	_, err = negativeXBounds.Validate("")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "must be numbers between 0 and 1")
+
+	negativeYBounds := makeValidConfig()
+	negativeYBounds.ValidRegions["box"][0].YMin = -0.2
+	_, err = negativeYBounds.Validate("")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "must be numbers between 0 and 1")
+
+	incorrectOrderX := makeValidConfig()
+	incorrectOrderX.ValidRegions["box"][0].XMin = 0.99
+	_, err = incorrectOrderX.Validate("")
+	test.That(t, err, test.ShouldNotBeNil)
+	fmt.Println(incorrectOrderX)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "must be less than x_max")
+
+	incorrectOrderY := makeValidConfig()
+	incorrectOrderY.ValidRegions["box"][0].YMin = 0.99
+	_, err = incorrectOrderY.Validate("")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "must be less than y_max")
+
+}

--- a/waitsensor/waitsensor_test.go
+++ b/waitsensor/waitsensor_test.go
@@ -28,13 +28,40 @@ func makeValidConfig() Config {
 
 
 func TestValidateEmpty(t *testing.T) {
+	var err error
+
 	cfg := Config{}
-	_, err := cfg.Validate("")
+	_, err = cfg.Validate("")
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "detector_name")
+
+	missingName := makeValidConfig()
+	missingName.DetectorName = ""
+	_, err = missingName.Validate("")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "detector_name")
+
+	missingSamples := makeValidConfig()
+	missingSamples.NSamples = 0.0
+	_, err = missingSamples.Validate("")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "n_samples")
+
+	missingThresholds := makeValidConfig()
+	missingThresholds.CountThresholds = nil
+	_, err = missingThresholds.Validate("")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "count_thresholds")
+
+	missingRegions := makeValidConfig()
+	missingRegions.ValidRegions = nil
+	_, err = missingRegions.Validate("")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "valid_regions")
+
 }
 
-func TestValidateCorrect(t *testing.T) {
+func TestValidateValid(t *testing.T) {
 	var err error
 
 	validConfig := makeValidConfig()
@@ -44,6 +71,16 @@ func TestValidateCorrect(t *testing.T) {
 	// Note that you can have a 0-area bounding box! We'll just ignore it and use the whole image.
 	validConfig.ValidRegions["box"][0].XMin = 0
 	validConfig.ValidRegions["box"][0].XMax = 0
+	_, err = validConfig.Validate("")
+	test.That(t, err, test.ShouldBeNil)
+
+	// and it's okay not to have a blank valid region!
+	validConfig.ValidRegions["box"][0] = BoundingBoxConfig{}
+	_, err = validConfig.Validate("")
+	test.That(t, err, test.ShouldBeNil)
+
+	// It's also okay to have a missing CountPeriod
+	validConfig.CountPeriod = 0.0
 	_, err = validConfig.Validate("")
 	test.That(t, err, test.ShouldBeNil)
 }

--- a/waitsensor/waitsensor_test.go
+++ b/waitsensor/waitsensor_test.go
@@ -35,8 +35,16 @@ func TestValidateEmpty(t *testing.T) {
 }
 
 func TestValidateCorrect(t *testing.T) {
+	var err error
+
 	validConfig := makeValidConfig()
-	_, err := validConfig.Validate("")
+	_, err = validConfig.Validate("")
+	test.That(t, err, test.ShouldBeNil)
+
+	// Note that you can have a 0-area bounding box! We'll just ignore it and use the whole image.
+	validConfig.ValidRegions["box"][0].XMin = 0
+	validConfig.ValidRegions["box"][0].XMax = 0
+	_, err = validConfig.Validate("")
 	test.That(t, err, test.ShouldBeNil)
 }
 
@@ -68,4 +76,15 @@ func TestValidateInvalidBoundingBox(t *testing.T) {
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "must be less than y_max")
 
+	tooBigX := makeValidConfig()
+	tooBigX.ValidRegions["box"][0].XMax = 2.0
+	_, err = tooBigX.Validate("")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "must be numbers between 0 and 1")
+
+	tooBigY := makeValidConfig()
+	tooBigY.ValidRegions["box"][0].YMax = 2.0
+	_, err = tooBigY.Validate("")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "must be numbers between 0 and 1")
 }

--- a/waitsensor/waitsensor_test.go
+++ b/waitsensor/waitsensor_test.go
@@ -9,23 +9,22 @@ import (
 
 func makeValidConfig() Config {
 	return Config{DetectorName: "test",
-	                     CountPeriod: 5.0,
-	                     NSamples: 10,
-						 CountThresholds: map[string]int{
-							 "one": 1,
-							 "two": 2,
-							 "three": 3,
-						 },
-	                     ValidRegions: map[string][]BoundingBoxConfig{
-	                         "box": {{XMin: 0.25,
-	                                  XMax: 0.75,
-	                                  YMin: 0.10,
-	                                  YMax: 0.90,
-	                                  }},
-	                     },
-		        	 }
-				 }
-
+		CountPeriod: 5.0,
+		NSamples:    10,
+		CountThresholds: map[string]int{
+			"one":   1,
+			"two":   2,
+			"three": 3,
+		},
+		ValidRegions: map[string][]BoundingBoxConfig{
+			"box": {{XMin: 0.25,
+				XMax: 0.75,
+				YMin: 0.10,
+				YMax: 0.90,
+			}},
+		},
+	}
+}
 
 func TestValidateEmpty(t *testing.T) {
 	var err error

--- a/waitsensor/waitsensor_test.go
+++ b/waitsensor/waitsensor_test.go
@@ -6,9 +6,35 @@ import (
 	"go.viam.com/test"
 )
 
-func TestValidate(t *testing.T) {
+var validConfig = Config{DetectorName: "test",
+	                     CountPeriod: 5.0,
+	                     NSamples: 10,
+	                     ValidRegions: map[string][]BoundingBoxConfig{
+	                         "one": {XMin: 0.25,
+	                                 XMin: 0.25,
+	                                 YMax: 0.10,
+	                                 YMax: 0.90,
+	                                 },
+	                     },
+		        	 }
+
+func TestValidateEmpty(t *testing.T) {
 	cfg := Config{}
 	_, err := cfg.Validate("")
 	test.That(t, err, test.ShouldNotBeNil)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "detector_name")
 }
+
+func TestValidateCorrect(t *testing.T) {
+	_, err := validConfig.Validate("")
+	test.That(t, err, test.ShouldBeNil)
+}
+
+func TestValidateInvalidBoundingBox(t *testing.T) {
+	negativeBounds := validConfig
+	negativeBounds.ValidRegions["one"].XMin = -0.2
+	_, err := cfg.Validate("")
+	test.That(t, err, test.ShouldNotBeNil)
+	test.That(t, err.Error(), test.ShouldContainSubstring, "detector_name")
+}
+

--- a/waitsensor/waitsensor_test.go
+++ b/waitsensor/waitsensor_test.go
@@ -1,7 +1,6 @@
 package waitsensor
 
 import (
-	"fmt"
 	"testing"
 
 	"go.viam.com/test"
@@ -103,7 +102,6 @@ func TestValidateInvalidBoundingBox(t *testing.T) {
 	incorrectOrderX.ValidRegions["box"][0].XMin = 0.99
 	_, err = incorrectOrderX.Validate("")
 	test.That(t, err, test.ShouldNotBeNil)
-	fmt.Println(incorrectOrderX)
 	test.That(t, err.Error(), test.ShouldContainSubstring, "must be less than x_max")
 
 	incorrectOrderY := makeValidConfig()


### PR DESCRIPTION
Everything compiles, but I haven't tried running it yet. I'll do that while you take a look at the changes...

(doing this now because Alexis got confused why a ticket assigned to me was in her epic)