### PR TITLE
include meta.json in module.tar.gz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ lint:
 		go mod tidy
 		golangci-lint run
 
-module.tar.gz: go.mod go.sum waitsensor/waitsensor.go cmd/module/main.go
+module.tar.gz: go.mod go.sum meta.json waitsensor/waitsensor.go cmd/module/main.go
 	go build -a -o module ./cmd/module
-	tar -czf $@ module
+	tar -czf $@ meta.json module
 
 clean:
 	rm -rf module module.tar.gz


### PR DESCRIPTION
This should help with testing things out as a local module. For code deployed via the modular registry, this shouldn't change anything.

I've run `make module.tar.gz`, and it builds the tarball correctly.